### PR TITLE
Fix content validator model link to open IDE

### DIFF
--- a/.github/workflows/content-validator.yml
+++ b/.github/workflows/content-validator.yml
@@ -126,7 +126,7 @@ jobs:
               ? (report.base_url.endsWith('/') ? report.base_url.slice(0, -1) : report.base_url)
               : null;
             const modelUrl = baseUrl && report.model_id
-              ? `${baseUrl}/models/${report.model_id}`
+              ? `${baseUrl}/models/${report.model_id}/ide`
               : null;
             const summary = [
               `Total issues: ${report.total_issues}`,


### PR DESCRIPTION
## Summary
- append `/ide` to the model URL shown in the content validator workflow summary
- keep the existing base URL normalization logic unchanged

## Verification
- verified the workflow diff locally to confirm the generated link now targets the model IDE route

Closes #1.

Thanks @bthomson22 for catching and reporting this.