### PR TITLE
feat: add clickable dashboard links to validator comments

### DIFF
--- a/.github/workflows/content-validator.yml
+++ b/.github/workflows/content-validator.yml
@@ -137,13 +137,31 @@ jobs:
               reportMissing ? 'Report missing: validator did not produce output.' : null,
             ].filter(Boolean).join('\n');
 
+            const escapeMarkdownLinkText = (value) => String(value)
+              .replace(/\\/g, '\\\\')
+              .replace(/\[/g, '\\[')
+              .replace(/\]/g, '\\]');
+
             const formatList = (items) => {
               if (!items || items.length === 0) return '_None_';
               return items.map((item) => {
                 const raw = item.raw || {};
-                const docName = raw.document_name || 'Unknown document';
-                const queryName = raw.query_name || raw.issue_type || 'Issue';
-                const header = `${docName} / ${queryName}`;
+                const docName = raw.document_name || raw.name || 'Unknown document';
+                const queryName = raw.query_name || null;
+                const issueType = raw.issue_type || null;
+                const documentUrl = typeof raw.document_url === 'string'
+                  ? raw.document_url
+                  : (typeof raw.url === 'string' ? raw.url : null);
+                const docLabel = documentUrl
+                  ? `[${escapeMarkdownLinkText(docName)}](${documentUrl})`
+                  : docName;
+                const headerParts = [docLabel];
+                if (queryName) {
+                  headerParts.push(queryName);
+                } else if (issueType) {
+                  headerParts.push(issueType);
+                }
+                const header = headerParts.join(' / ');
                 const message = raw.message || item.summary || 'No details';
                 return `- ${header}\n\n\`\`\`\n${message}\n\`\`\``;
               }).join('\n');

--- a/src/omni_content_validator/cli.py
+++ b/src/omni_content_validator/cli.py
@@ -51,6 +51,9 @@ def _collect_content_issues(payload: Dict[str, Any]) -> List[Any]:
             "document_id": document.get("document_id"),
             "document_name": document.get("name"),
             "document_type": document.get("type"),
+            "document_url": document.get("url")
+            if isinstance(document.get("url"), str)
+            else None,
             "folder_name": document.get("folder", {}).get("name")
             if isinstance(document.get("folder"), dict)
             else None,


### PR DESCRIPTION
## Summary
- preserve the document URL in normalized content issues so nested validator items still know which dashboard they came from
- render the document name in the PR comment as a markdown link when either `document_url` or `url` is present
- keep plain-text fallbacks when the API payload does not include a URL

## Verification
- exercised `_collect_content_issues` with a synthetic payload and confirmed nested dashboard/query issues inherit `document_url`
- reviewed the workflow diff to confirm PR comments now link the dashboard name without changing the surrounding summary output