### PR TITLE
feat: add include-personal-folders support

### DIFF
--- a/.github/workflows/content-validator.yml
+++ b/.github/workflows/content-validator.yml
@@ -19,6 +19,7 @@ jobs:
       OMNI_API_KEY: ${{ secrets.OMNI_API_KEY }}
       OMNI_USER_ID: ${{ vars.OMNI_USER_ID || secrets.OMNI_USER_ID }}
       OMNI_BRANCH_ID: ${{ vars.OMNI_BRANCH_ID || secrets.OMNI_BRANCH_ID }}
+      OMNI_INCLUDE_PERSONAL_FOLDERS: ${{ vars.OMNI_INCLUDE_PERSONAL_FOLDERS || secrets.OMNI_INCLUDE_PERSONAL_FOLDERS }}
       OMNI_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     steps:
       - name: Checkout
@@ -115,6 +116,7 @@ jobs:
                 new_issues: 0,
                 existing_issues: 0,
                 resolved_issues: 0,
+                include_personal_folders: false,
                 new_issue_samples: [],
                 existing_issue_samples: [],
                 resolved_issue_samples: [],
@@ -133,6 +135,7 @@ jobs:
               `New issues: ${report.new_issues}`,
               `Existing issues: ${report.existing_issues}`,
               `Resolved issues: ${report.resolved_issues}`,
+              report.include_personal_folders ? 'Scope: includes personal folders' : null,
               modelUrl ? `Model: ${modelUrl}` : null,
               reportMissing ? 'Report missing: validator did not produce output.' : null,
             ].filter(Boolean).join('\n');

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Optional flags:
 - `--user-id` to act on behalf of a user for org API keys.
 - `--branch-name` to resolve and validate against an Omni branch with the same name.
 - `--branch-id` to validate against a specific Omni branch UUID.
+- `--include-personal-folders` to include personal folders in the validation search.
 - `--issues-path` to point at the array of issues in the JSON response (dot path). By default, the CLI looks for `issues` arrays or the `content[].queries_and_issues[].issues` and `content[].dashboard_filter_issues` arrays.
 - `--fail-on-new-only` to fail only when new issues appear vs history.
 - `--auth-header` and `--auth-scheme` to override auth header formatting (defaults to `Authorization: Bearer <token>`).
@@ -41,6 +42,7 @@ Environment variables:
 - `OMNI_MODEL_ID`
 - `OMNI_API_KEY`
 - `OMNI_USER_ID`
+- `OMNI_INCLUDE_PERSONAL_FOLDERS`
 - `OMNI_ISSUES_PATH`
 - `OMNI_BRANCH_ID` (optional override if you already know the Omni branch UUID)
 - `OMNI_BRANCH_NAME` (used to resolve the Omni branch UUID by name)
@@ -52,6 +54,7 @@ export OMNI_BASE_URL="https://ernesto.playground.exploreomni.dev"
 export OMNI_MODEL_ID="..."
 export OMNI_API_KEY="..."
 export OMNI_USER_ID="..." # optional
+export OMNI_INCLUDE_PERSONAL_FOLDERS="true" # optional
 ```
 
 ## GitHub Action
@@ -64,6 +67,7 @@ Configure these in GitHub:
 - `OMNI_BASE_URL` (variable or secret)
 - `OMNI_MODEL_ID` (variable or secret)
 - `OMNI_USER_ID` (optional variable or secret)
+- `OMNI_INCLUDE_PERSONAL_FOLDERS` (optional variable or secret)
 
 ### Testing the workflow
 

--- a/src/omni_content_validator/cli.py
+++ b/src/omni_content_validator/cli.py
@@ -200,6 +200,13 @@ def _build_headers(api_key: str, auth_header: str, auth_scheme: str) -> Dict[str
     return {auth_header: token_value}
 
 
+def _env_flag(name: str) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Run Omni content validator and track history",
@@ -213,6 +220,12 @@ def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     parser.add_argument("--auth-header", default="Authorization")
     parser.add_argument("--auth-scheme", default="Bearer")
     parser.add_argument("--issues-path", default=os.getenv("OMNI_ISSUES_PATH"))
+    parser.add_argument(
+        "--include-personal-folders",
+        action=argparse.BooleanOptionalAction,
+        default=_env_flag("OMNI_INCLUDE_PERSONAL_FOLDERS"),
+        help="Include personal folders in the validation search",
+    )
     parser.add_argument("--timeout", type=int, default=60)
     parser.add_argument("--history-in", default=".omni-content-validator/history.json")
     parser.add_argument("--history-out", default=".omni-content-validator/history.json")
@@ -246,6 +259,8 @@ def _fetch_validator_payload(args: argparse.Namespace) -> Any:
         params["userId"] = args.user_id
     if args.branch_id:
         params["branch_id"] = args.branch_id
+    if args.include_personal_folders:
+        params["include_personal_folders"] = "true"
 
     response = requests.get(url, headers=headers, params=params, timeout=args.timeout)
     if not response.ok:
@@ -324,6 +339,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         "generated_at": datetime.datetime.utcnow().isoformat() + "Z",
         "base_url": args.base_url,
         "model_id": args.model_id,
+        "include_personal_folders": args.include_personal_folders,
         "total_issues": len(normalized),
         "new_issues": len(new_items),
         "existing_issues": len(existing_items),
@@ -341,6 +357,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             "generated_at": report["generated_at"],
             "base_url": args.base_url,
             "model_id": args.model_id,
+            "include_personal_folders": args.include_personal_folders,
             "issues": normalized,
         },
     )


### PR DESCRIPTION
## Summary
- add `--include-personal-folders` to the CLI, with `OMNI_INCLUDE_PERSONAL_FOLDERS` as the default source for automation
- send `include_personal_folders=true` to the content validator endpoint when the flag is enabled
- expose the setting in the GitHub workflow environment and surface it in the validation summary when active

## Verification
- verified CLI parsing from `OMNI_INCLUDE_PERSONAL_FOLDERS`, including `--no-include-personal-folders` override behavior
- verified the validator request includes `include_personal_folders=true` when enabled
- validated `.github/workflows/content-validator.yml` with Ruby's YAML parser
- compiled `src/omni_content_validator/cli.py` successfully with `PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile`