### PR TITLE
ci: opt release-please into Node 24

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - name: Run Release Please
         id: release


### PR DESCRIPTION
## Summary
- opt the `Release Please` workflow into Node 24 via `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`
- keep the existing `googleapis/release-please-action@v4` usage unchanged
- remove the deprecation path for the action runtime without waiting on a new action runtime declaration

## Verification
- validated `.github/workflows/release-please.yml` with Ruby's YAML parser
- confirmed the latest `release-please-action` release still declares `runs.using: node20`, so the workflow-level opt-in is the correct short-term fix