### PR TITLE
feat: support label-filtered validator results

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,24 @@
+name: Secret Scan
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Scan for leaked secrets
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: "false"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks

--- a/README.md
+++ b/README.md
@@ -82,12 +82,37 @@ export OMNI_LABELS="Verified,Sales" # optional
 export OMNI_INCLUDE_PERSONAL_FOLDERS="true" # optional
 ```
 
+## Secret Safety
+
+This repo now has two guardrails against accidentally committing keys:
+
+- A local `pre-commit` hook using the official `gitleaks` hook.
+- A GitHub Actions backstop in `.github/workflows/secret-scan.yml` that scans every push and pull request.
+
+Set up the local hook once per clone:
+
+```bash
+python3 -m pip install pre-commit
+pre-commit install
+```
+
+Run it manually across the repo at any time:
+
+```bash
+pre-commit run --all-files
+```
+
+Operationally, secrets should still live in environment variables or GitHub Actions secrets, never in tracked files. `.env` files and `.omni-content-validator/` artifacts are already ignored in `.gitignore`.
+
+For server-side blocking before a push lands, enable GitHub Secret Scanning and Push Protection in the repository settings. That setting is outside the repo, so it is not something this codebase can enforce by itself.
+
 ## GitHub Actions
 
 This repo includes live workflows for:
 
 - `.github/workflows/actionlint.yml`
 - `.github/workflows/release-please.yml`
+- `.github/workflows/secret-scan.yml`
 
 The content validator workflow is kept as an example in `.github/workflow-examples/content-validator.yml` so it does not run automatically in this repository. To enable it in your own repo, copy it to `.github/workflows/content-validator.yml`.
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,34 @@ omni-content-validator \
   --branch-name <BRANCH_NAME>
 ```
 
+Validate only labeled content:
+
+```bash
+omni-content-validator \
+  --base-url https://ernesto.playground.exploreomni.dev \
+  --model-id <MODEL_ID> \
+  --api-key <API_KEY> \
+  --labels Verified
+```
+
+Or use repeated label flags:
+
+```bash
+omni-content-validator \
+  --base-url https://ernesto.playground.exploreomni.dev \
+  --model-id <MODEL_ID> \
+  --api-key <API_KEY> \
+  --label Verified \
+  --label Sales
+```
+
 Optional flags:
 
 - `--user-id` to act on behalf of a user for org API keys.
 - `--branch-name` to resolve and validate against an Omni branch with the same name.
 - `--branch-id` to validate against a specific Omni branch UUID.
+- `--labels` to filter validation results by one or more Omni labels (comma-separated, for example `--labels Verified,Sales`).
+- `--label` as a repeatable form of the same filter (for example `--label Verified --label Sales`).
 - `--include-personal-folders` to include personal folders in the validation search.
 - `--issues-path` to point at the array of issues in the JSON response (dot path). By default, the CLI looks for `issues` arrays or the `content[].queries_and_issues[].issues` and `content[].dashboard_filter_issues` arrays.
 - `--fail-on-new-only` to fail only when new issues appear vs history.
@@ -42,6 +65,7 @@ Environment variables:
 - `OMNI_MODEL_ID`
 - `OMNI_API_KEY`
 - `OMNI_USER_ID`
+- `OMNI_LABELS` (optional comma-separated label filter, for example `Verified,Sales`)
 - `OMNI_INCLUDE_PERSONAL_FOLDERS`
 - `OMNI_ISSUES_PATH`
 - `OMNI_BRANCH_ID` (optional override if you already know the Omni branch UUID)
@@ -54,6 +78,7 @@ export OMNI_BASE_URL="https://ernesto.playground.exploreomni.dev"
 export OMNI_MODEL_ID="..."
 export OMNI_API_KEY="..."
 export OMNI_USER_ID="..." # optional
+export OMNI_LABELS="Verified,Sales" # optional
 export OMNI_INCLUDE_PERSONAL_FOLDERS="true" # optional
 ```
 
@@ -92,7 +117,11 @@ Releases are managed in this repo by `.github/workflows/release-please.yml`.
 
 ## Limitations
 
-The content validator endpoint currently validates all content and does not support filters. That means the PR report may include unrelated failures. The example workflow keeps a history artifact and highlights which issues are new vs previously seen to reduce noise.
+The content validator endpoint currently validates all content and does not support filters server-side.
+
+When you pass `--labels` or `OMNI_LABELS`, this CLI first fetches matching content from `/api/v1/content?include=labels` and then filters the validator payload locally before extracting issues. That keeps reports and history scoped to the labeled subset, but Omni still validates the full model underneath.
+
+Without label filtering, the PR report may include unrelated failures. The example workflow keeps a history artifact and highlights which issues are new vs previously seen to reduce noise.
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ Releases are managed in this repo by `.github/workflows/release-please.yml`.
 
 The content validator endpoint currently validates all content and does not support filters server-side.
 
-When you pass `--labels` or `OMNI_LABELS`, this CLI first fetches matching content from `/api/v1/content?include=labels` and then filters the validator payload locally before extracting issues. That keeps reports and history scoped to the labeled subset, but Omni still validates the full model underneath.
+This CLI also fetches content metadata from `/api/v1/content` to enrich issue records with document ownership information. Reports now include `document_owner` when Omni returns an owner object for the matched content.
+
+When you pass `--labels` or `OMNI_LABELS`, the same content API lookup is reused to filter the validator payload locally before extracting issues. That keeps reports and history scoped to the labeled subset, but Omni still validates the full model underneath.
 
 Without label filtering, the PR report may include unrelated failures. The example workflow keeps a history artifact and highlights which issues are new vs previously seen to reduce noise.
 

--- a/src/omni_content_validator/cli.py
+++ b/src/omni_content_validator/cli.py
@@ -3,8 +3,7 @@ import datetime
 import hashlib
 import json
 import os
-import sys
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 import requests
 
@@ -38,6 +37,25 @@ def _extract_by_path(payload: Any, path: Optional[str]) -> Optional[List[Any]]:
     return None
 
 
+def _extract_label_names(record: Dict[str, Any]) -> Optional[List[str]]:
+    labels = record.get("labels")
+    if not isinstance(labels, list):
+        return None
+
+    names = []
+    for item in labels:
+        if isinstance(item, dict):
+            value = item.get("name")
+        else:
+            value = item
+        if isinstance(value, str) and value.strip():
+            names.append(value.strip())
+
+    if not names:
+        return None
+    return names
+
+
 def _collect_content_issues(payload: Dict[str, Any]) -> List[Any]:
     issues: List[Any] = []
     content = payload.get("content")
@@ -49,6 +67,7 @@ def _collect_content_issues(payload: Dict[str, Any]) -> List[Any]:
             continue
         doc_context = {
             "document_id": document.get("document_id"),
+            "document_identifier": document.get("identifier"),
             "document_name": document.get("name"),
             "document_type": document.get("type"),
             "document_url": document.get("url")
@@ -60,6 +79,7 @@ def _collect_content_issues(payload: Dict[str, Any]) -> List[Any]:
             "folder_path": document.get("folder", {}).get("path")
             if isinstance(document.get("folder"), dict)
             else None,
+            "document_labels": _extract_label_names(document),
         }
         dashboard_issues = document.get("dashboard_filter_issues")
         if isinstance(dashboard_issues, list):
@@ -210,6 +230,26 @@ def _env_flag(name: str) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _split_csv_values(values: Iterable[Optional[str]]) -> List[str]:
+    names = []
+    for value in values:
+        if not isinstance(value, str):
+            continue
+        for item in value.split(","):
+            name = item.strip()
+            if name:
+                names.append(name)
+    return list(dict.fromkeys(names))
+
+
+def _normalize_history_labels(value: Any) -> List[str]:
+    if isinstance(value, list):
+        return _split_csv_values(value)
+    if isinstance(value, str):
+        return _split_csv_values([value])
+    return []
+
+
 def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Run Omni content validator and track history",
@@ -223,6 +263,18 @@ def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     parser.add_argument("--auth-header", default="Authorization")
     parser.add_argument("--auth-scheme", default="Bearer")
     parser.add_argument("--issues-path", default=os.getenv("OMNI_ISSUES_PATH"))
+    parser.add_argument(
+        "--labels",
+        action="append",
+        default=[],
+        help="Comma-separated label names to filter validation results by",
+    )
+    parser.add_argument(
+        "--label",
+        action="append",
+        default=[],
+        help="Repeatable label name to filter validation results by",
+    )
     parser.add_argument(
         "--include-personal-folders",
         action=argparse.BooleanOptionalAction,
@@ -239,7 +291,13 @@ def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         action="store_true",
         help="Only fail when there are new issues compared to history",
     )
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+
+    cli_labels = _split_csv_values([*args.labels, *args.label])
+    env_labels = _split_csv_values([os.getenv("OMNI_LABELS")])
+    args.labels = cli_labels or env_labels
+    delattr(args, "label")
+    return args
 
 
 def _validate_args(args: argparse.Namespace) -> None:
@@ -275,6 +333,72 @@ def _fetch_validator_payload(args: argparse.Namespace) -> Any:
         raise SystemExit(f"Content validator did not return JSON: {exc}") from exc
 
     return payload
+
+
+def _fetch_content_identifiers_for_labels(args: argparse.Namespace) -> Set[str]:
+    headers = _build_headers(args.api_key, args.auth_header, args.auth_scheme)
+    url = f"{args.base_url.rstrip('/')}/api/v1/content"
+    identifiers: Set[str] = set()
+    cursor = None
+
+    while True:
+        params = {
+            "include": "labels",
+            "labels": ",".join(args.labels),
+        }
+        if cursor:
+            params["cursor"] = cursor
+        if args.user_id:
+            params["userId"] = args.user_id
+        if args.branch_id:
+            params["branch_id"] = args.branch_id
+        if args.include_personal_folders:
+            params["include_personal_folders"] = "true"
+
+        response = requests.get(url, headers=headers, params=params, timeout=args.timeout)
+        if not response.ok:
+            raise SystemExit(
+                f"Content lookup failed: {response.status_code} {response.text}"
+            )
+
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise SystemExit(f"Content lookup did not return JSON: {exc}") from exc
+
+        records = payload.get("records", [])
+        if isinstance(records, list):
+            for record in records:
+                if not isinstance(record, dict):
+                    continue
+                identifier = record.get("identifier")
+                if isinstance(identifier, str) and identifier.strip():
+                    identifiers.add(identifier)
+
+        cursor = payload.get("pageInfo", {}).get("nextCursor")
+        if not cursor:
+            return identifiers
+
+
+def _filter_validator_payload(
+    payload: Any, allowed_identifiers: Set[str]
+) -> Any:
+    if not isinstance(payload, dict):
+        return payload
+
+    content = payload.get("content")
+    if not isinstance(content, list):
+        return payload
+
+    filtered_payload = dict(payload)
+    filtered_payload["content"] = [
+        document
+        for document in content
+        if isinstance(document, dict)
+        and isinstance(document.get("identifier"), str)
+        and document.get("identifier") in allowed_identifiers
+    ]
+    return filtered_payload
 
 
 def _resolve_branch_id(args: argparse.Namespace) -> Optional[str]:
@@ -325,6 +449,14 @@ def main(argv: Optional[List[str]] = None) -> int:
         print(f"No matching Omni branch found for '{args.branch_name}', using default")
 
     payload = _fetch_validator_payload(args)
+    if args.labels:
+        allowed_identifiers = _fetch_content_identifiers_for_labels(args)
+        payload = _filter_validator_payload(payload, allowed_identifiers)
+        print(
+            "Filtered validator payload by labels "
+            f"{', '.join(args.labels)} "
+            f"to {len(payload.get('content', [])) if isinstance(payload, dict) else 0} document(s)"
+        )
     if args.raw_response_out:
         _write_json(args.raw_response_out, {"payload": payload})
 
@@ -332,7 +464,13 @@ def main(argv: Optional[List[str]] = None) -> int:
     normalized = _normalize_issues(issues)
 
     previous_payload = _load_json(args.history_in) or {}
-    previous_issues = previous_payload.get("issues", [])
+    previous_labels = _normalize_history_labels(previous_payload.get("labels"))
+    if previous_labels != args.labels:
+        if previous_payload:
+            print("History labels changed; ignoring previous issues for comparison")
+        previous_issues = []
+    else:
+        previous_issues = previous_payload.get("issues", [])
 
     new_items, existing_items, resolved_items = _partition_issues(
         normalized, previous_issues
@@ -342,6 +480,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         "generated_at": datetime.datetime.utcnow().isoformat() + "Z",
         "base_url": args.base_url,
         "model_id": args.model_id,
+        "labels": args.labels,
         "include_personal_folders": args.include_personal_folders,
         "total_issues": len(normalized),
         "new_issues": len(new_items),
@@ -360,6 +499,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             "generated_at": report["generated_at"],
             "base_url": args.base_url,
             "model_id": args.model_id,
+            "labels": args.labels,
             "include_personal_folders": args.include_personal_folders,
             "issues": normalized,
         },

--- a/src/omni_content_validator/cli.py
+++ b/src/omni_content_validator/cli.py
@@ -56,6 +56,25 @@ def _extract_label_names(record: Dict[str, Any]) -> Optional[List[str]]:
     return names
 
 
+def _extract_owner(record: Dict[str, Any]) -> Optional[Dict[str, str]]:
+    owner = record.get("owner")
+    if not isinstance(owner, dict):
+        return None
+
+    normalized_owner = {}
+    owner_id = owner.get("id")
+    if isinstance(owner_id, str) and owner_id.strip():
+        normalized_owner["id"] = owner_id.strip()
+
+    owner_name = owner.get("name")
+    if isinstance(owner_name, str) and owner_name.strip():
+        normalized_owner["name"] = owner_name.strip()
+
+    if not normalized_owner:
+        return None
+    return normalized_owner
+
+
 def _collect_content_issues(payload: Dict[str, Any]) -> List[Any]:
     issues: List[Any] = []
     content = payload.get("content")
@@ -80,6 +99,7 @@ def _collect_content_issues(payload: Dict[str, Any]) -> List[Any]:
             if isinstance(document.get("folder"), dict)
             else None,
             "document_labels": _extract_label_names(document),
+            "document_owner": _extract_owner(document),
         }
         dashboard_issues = document.get("dashboard_filter_issues")
         if isinstance(dashboard_issues, list):
@@ -157,7 +177,14 @@ def _issue_identity(issue: Any) -> str:
         value = issue
     else:
         try:
-            value = json.dumps(issue, sort_keys=True, separators=(",", ":"))
+            comparable_issue = issue
+            if isinstance(issue, dict):
+                comparable_issue = dict(issue)
+                comparable_issue.pop("document_labels", None)
+                comparable_issue.pop("document_owner", None)
+            value = json.dumps(
+                comparable_issue, sort_keys=True, separators=(",", ":")
+            )
         except TypeError:
             value = str(issue)
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
@@ -335,17 +362,17 @@ def _fetch_validator_payload(args: argparse.Namespace) -> Any:
     return payload
 
 
-def _fetch_content_identifiers_for_labels(args: argparse.Namespace) -> Set[str]:
+def _fetch_content_records(args: argparse.Namespace) -> List[Dict[str, Any]]:
     headers = _build_headers(args.api_key, args.auth_header, args.auth_scheme)
     url = f"{args.base_url.rstrip('/')}/api/v1/content"
-    identifiers: Set[str] = set()
+    records: List[Dict[str, Any]] = []
     cursor = None
 
     while True:
-        params = {
-            "include": "labels",
-            "labels": ",".join(args.labels),
-        }
+        params = {}
+        if args.labels:
+            params["include"] = "labels"
+            params["labels"] = ",".join(args.labels)
         if cursor:
             params["cursor"] = cursor
         if args.user_id:
@@ -366,18 +393,27 @@ def _fetch_content_identifiers_for_labels(args: argparse.Namespace) -> Set[str]:
         except ValueError as exc:
             raise SystemExit(f"Content lookup did not return JSON: {exc}") from exc
 
-        records = payload.get("records", [])
-        if isinstance(records, list):
-            for record in records:
+        page_records = payload.get("records", [])
+        if isinstance(page_records, list):
+            for record in page_records:
                 if not isinstance(record, dict):
                     continue
-                identifier = record.get("identifier")
-                if isinstance(identifier, str) and identifier.strip():
-                    identifiers.add(identifier)
+                records.append(record)
 
         cursor = payload.get("pageInfo", {}).get("nextCursor")
         if not cursor:
-            return identifiers
+            return records
+
+
+def _index_content_records(
+    records: Iterable[Dict[str, Any]]
+) -> Dict[str, Dict[str, Any]]:
+    indexed_records = {}
+    for record in records:
+        identifier = record.get("identifier")
+        if isinstance(identifier, str) and identifier.strip():
+            indexed_records[identifier] = record
+    return indexed_records
 
 
 def _filter_validator_payload(
@@ -399,6 +435,46 @@ def _filter_validator_payload(
         and document.get("identifier") in allowed_identifiers
     ]
     return filtered_payload
+
+
+def _enrich_validator_payload(
+    payload: Any, content_records_by_identifier: Dict[str, Dict[str, Any]]
+) -> Any:
+    if not isinstance(payload, dict):
+        return payload
+
+    content = payload.get("content")
+    if not isinstance(content, list):
+        return payload
+
+    enriched_payload = dict(payload)
+    enriched_content = []
+    for document in content:
+        if not isinstance(document, dict):
+            enriched_content.append(document)
+            continue
+
+        enriched_document = dict(document)
+        identifier = enriched_document.get("identifier")
+        content_record = None
+        if isinstance(identifier, str):
+            content_record = content_records_by_identifier.get(identifier)
+
+        if isinstance(content_record, dict):
+            owner = _extract_owner(content_record)
+            if owner is not None and not isinstance(enriched_document.get("owner"), dict):
+                enriched_document["owner"] = owner
+
+            labels = content_record.get("labels")
+            if isinstance(labels, list) and not isinstance(
+                enriched_document.get("labels"), list
+            ):
+                enriched_document["labels"] = labels
+
+        enriched_content.append(enriched_document)
+
+    enriched_payload["content"] = enriched_content
+    return enriched_payload
 
 
 def _resolve_branch_id(args: argparse.Namespace) -> Optional[str]:
@@ -449,14 +525,21 @@ def main(argv: Optional[List[str]] = None) -> int:
         print(f"No matching Omni branch found for '{args.branch_name}', using default")
 
     payload = _fetch_validator_payload(args)
-    if args.labels:
-        allowed_identifiers = _fetch_content_identifiers_for_labels(args)
-        payload = _filter_validator_payload(payload, allowed_identifiers)
-        print(
-            "Filtered validator payload by labels "
-            f"{', '.join(args.labels)} "
-            f"to {len(payload.get('content', [])) if isinstance(payload, dict) else 0} document(s)"
-        )
+    content_records_by_identifier = {}
+    if isinstance(payload, dict) and isinstance(payload.get("content"), list):
+        content_records = _fetch_content_records(args)
+        content_records_by_identifier = _index_content_records(content_records)
+
+        if args.labels:
+            allowed_identifiers = set(content_records_by_identifier)
+            payload = _filter_validator_payload(payload, allowed_identifiers)
+            print(
+                "Filtered validator payload by labels "
+                f"{', '.join(args.labels)} "
+                f"to {len(payload.get('content', [])) if isinstance(payload, dict) else 0} document(s)"
+            )
+
+        payload = _enrich_validator_payload(payload, content_records_by_identifier)
     if args.raw_response_out:
         _write_json(args.raw_response_out, {"payload": payload})
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,8 +40,29 @@ class ParseArgsTests(unittest.TestCase):
         self.assertEqual(args.labels, ["Verified", "Sales", "Finance"])
 
 
+class IssueIdentityTests(unittest.TestCase):
+    def test_issue_identity_ignores_owner_and_labels_metadata(self):
+        base_issue = {
+            "message": "Broken field",
+            "document_id": "1",
+            "document_identifier": "dash-1",
+            "document_name": "Revenue Dashboard",
+            "issue_type": "query",
+        }
+
+        enriched_issue = {
+            **base_issue,
+            "document_labels": ["Verified"],
+            "document_owner": {"id": "membership-1", "name": "Alice"},
+        }
+
+        self.assertEqual(
+            cli._issue_identity(base_issue), cli._issue_identity(enriched_issue)
+        )
+
+
 class LabelFilteringTests(unittest.TestCase):
-    def test_fetch_content_identifiers_for_labels_paginates(self):
+    def test_fetch_content_records_paginates(self):
         args = argparse.Namespace(
             base_url="https://omni.example",
             api_key="secret",
@@ -70,9 +91,12 @@ class LabelFilteringTests(unittest.TestCase):
         ]
 
         with mock.patch.object(cli.requests, "get", side_effect=responses) as get:
-            identifiers = cli._fetch_content_identifiers_for_labels(args)
+            records = cli._fetch_content_records(args)
 
-        self.assertEqual(identifiers, {"doc-1", "doc-2", "doc-3"})
+        self.assertEqual(
+            [record["identifier"] for record in records],
+            ["doc-1", "doc-2", "doc-2", "doc-3"],
+        )
         self.assertEqual(get.call_count, 2)
         self.assertEqual(
             get.call_args_list[0].args[0], "https://omni.example/api/v1/content"
@@ -99,6 +123,30 @@ class LabelFilteringTests(unittest.TestCase):
             },
         )
 
+    def test_enrich_validator_payload_adds_owner_and_labels(self):
+        payload = {
+            "content": [
+                {"identifier": "doc-1", "name": "Alpha"},
+                {"identifier": "doc-2", "name": "Beta"},
+            ]
+        }
+        content_records_by_identifier = {
+            "doc-2": {
+                "identifier": "doc-2",
+                "owner": {"id": "membership-1", "name": "Alice"},
+                "labels": [{"name": "Verified"}],
+            }
+        }
+
+        enriched = cli._enrich_validator_payload(payload, content_records_by_identifier)
+
+        self.assertEqual(
+            enriched["content"][1]["owner"],
+            {"id": "membership-1", "name": "Alice"},
+        )
+        self.assertEqual(enriched["content"][1]["labels"], [{"name": "Verified"}])
+        self.assertNotIn("owner", payload["content"][1])
+
     def test_filter_validator_payload_filters_content_by_identifier(self):
         payload = {
             "content": [
@@ -114,7 +162,7 @@ class LabelFilteringTests(unittest.TestCase):
         self.assertEqual(filtered["meta"], {"page": 1})
         self.assertEqual(len(payload["content"]), 2)
 
-    def test_collect_content_issues_includes_document_identifier_and_labels(self):
+    def test_collect_content_issues_includes_document_identifier_labels_and_owner(self):
         payload = {
             "content": [
                 {
@@ -125,6 +173,7 @@ class LabelFilteringTests(unittest.TestCase):
                     "url": "https://omni.example/documents/1",
                     "folder": {"name": "Finance", "path": "/Finance"},
                     "labels": [{"name": "Verified"}],
+                    "owner": {"id": "membership-1", "name": "Alice"},
                     "queries_and_issues": [
                         {
                             "query_name": "Revenue by Month",
@@ -141,18 +190,21 @@ class LabelFilteringTests(unittest.TestCase):
         self.assertEqual(len(issues), 1)
         self.assertEqual(issues[0]["document_identifier"], "dash-1")
         self.assertEqual(issues[0]["document_labels"], ["Verified"])
+        self.assertEqual(
+            issues[0]["document_owner"], {"id": "membership-1", "name": "Alice"}
+        )
 
 
 class MainFlowTests(unittest.TestCase):
     @mock.patch.object(cli, "_write_json")
-    @mock.patch.object(cli, "_fetch_content_identifiers_for_labels")
+    @mock.patch.object(cli, "_fetch_content_records")
     @mock.patch.object(cli, "_fetch_validator_payload")
     @mock.patch.object(cli, "_load_json")
     def test_main_filters_results_and_resets_history_when_labels_change(
         self,
         load_json,
         fetch_validator_payload,
-        fetch_content_identifiers_for_labels,
+        fetch_content_records,
         write_json,
     ):
         fetch_validator_payload.return_value = {
@@ -175,7 +227,13 @@ class MainFlowTests(unittest.TestCase):
                 },
             ]
         }
-        fetch_content_identifiers_for_labels.return_value = {"dash-2"}
+        fetch_content_records.return_value = [
+            {
+                "identifier": "dash-2",
+                "owner": {"id": "membership-1", "name": "Alice"},
+                "labels": [{"name": "Verified"}],
+            }
+        ]
         load_json.return_value = {
             "labels": [],
             "issues": [{"id": "stale", "summary": "stale", "raw": {}}],
@@ -205,7 +263,63 @@ class MainFlowTests(unittest.TestCase):
         self.assertEqual(report["existing_issues"], 0)
         self.assertEqual(report["resolved_issues"], 0)
         self.assertEqual(history["labels"], ["Verified"])
+        self.assertEqual(
+            report["issues"][0]["raw"]["document_owner"],
+            {"id": "membership-1", "name": "Alice"},
+        )
+        self.assertEqual(report["issues"][0]["raw"]["document_labels"], ["Verified"])
         self.assertIn("History labels changed", stdout.getvalue())
+
+    @mock.patch.object(cli, "_write_json")
+    @mock.patch.object(cli, "_fetch_content_records")
+    @mock.patch.object(cli, "_fetch_validator_payload")
+    @mock.patch.object(cli, "_load_json")
+    def test_main_enriches_owner_without_labels(
+        self,
+        load_json,
+        fetch_validator_payload,
+        fetch_content_records,
+        write_json,
+    ):
+        fetch_validator_payload.return_value = {
+            "content": [
+                {
+                    "document_id": "2",
+                    "identifier": "dash-2",
+                    "name": "Revenue Dashboard",
+                    "queries_and_issues": [
+                        {"query_name": "Q2", "issues": [{"message": "Current issue"}]}
+                    ],
+                }
+            ]
+        }
+        fetch_content_records.return_value = [
+            {
+                "identifier": "dash-2",
+                "owner": {"id": "membership-2", "name": "Bob"},
+            }
+        ]
+        load_json.return_value = {"labels": [], "issues": []}
+
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = cli.main(
+                [
+                    "--base-url",
+                    "https://omni.example",
+                    "--model-id",
+                    "model-1",
+                    "--api-key",
+                    "secret",
+                ]
+            )
+
+        self.assertEqual(exit_code, 1)
+        report = write_json.call_args_list[0].args[1]
+        self.assertEqual(
+            report["issues"][0]["raw"]["document_owner"],
+            {"id": "membership-2", "name": "Bob"},
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,212 @@
+import argparse
+import contextlib
+import io
+import os
+import unittest
+from unittest import mock
+
+from omni_content_validator import cli
+
+
+class FakeResponse:
+    def __init__(self, payload, ok=True, status_code=200, text="OK"):
+        self._payload = payload
+        self.ok = ok
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+class ParseArgsTests(unittest.TestCase):
+    @mock.patch.dict(os.environ, {"OMNI_LABELS": "Verified, Sales, Verified"})
+    def test_parse_args_uses_env_labels_when_cli_missing(self):
+        args = cli._parse_args([])
+        self.assertEqual(args.labels, ["Verified", "Sales"])
+
+    @mock.patch.dict(os.environ, {"OMNI_LABELS": "Ignored"})
+    def test_parse_args_prefers_cli_labels_and_dedupes(self):
+        args = cli._parse_args(
+            [
+                "--labels",
+                "Verified,Sales",
+                "--label",
+                "Sales",
+                "--label",
+                "Finance",
+            ]
+        )
+        self.assertEqual(args.labels, ["Verified", "Sales", "Finance"])
+
+
+class LabelFilteringTests(unittest.TestCase):
+    def test_fetch_content_identifiers_for_labels_paginates(self):
+        args = argparse.Namespace(
+            base_url="https://omni.example",
+            api_key="secret",
+            auth_header="Authorization",
+            auth_scheme="Bearer",
+            labels=["Verified", "Sales"],
+            user_id="user-1",
+            branch_id="branch-1",
+            include_personal_folders=True,
+            timeout=30,
+        )
+
+        responses = [
+            FakeResponse(
+                {
+                    "records": [{"identifier": "doc-1"}, {"identifier": "doc-2"}],
+                    "pageInfo": {"nextCursor": "cursor-2"},
+                }
+            ),
+            FakeResponse(
+                {
+                    "records": [{"identifier": "doc-2"}, {"identifier": "doc-3"}],
+                    "pageInfo": {},
+                }
+            ),
+        ]
+
+        with mock.patch.object(cli.requests, "get", side_effect=responses) as get:
+            identifiers = cli._fetch_content_identifiers_for_labels(args)
+
+        self.assertEqual(identifiers, {"doc-1", "doc-2", "doc-3"})
+        self.assertEqual(get.call_count, 2)
+        self.assertEqual(
+            get.call_args_list[0].args[0], "https://omni.example/api/v1/content"
+        )
+        self.assertEqual(
+            get.call_args_list[0].kwargs["params"],
+            {
+                "include": "labels",
+                "labels": "Verified,Sales",
+                "userId": "user-1",
+                "branch_id": "branch-1",
+                "include_personal_folders": "true",
+            },
+        )
+        self.assertEqual(
+            get.call_args_list[1].kwargs["params"],
+            {
+                "include": "labels",
+                "labels": "Verified,Sales",
+                "cursor": "cursor-2",
+                "userId": "user-1",
+                "branch_id": "branch-1",
+                "include_personal_folders": "true",
+            },
+        )
+
+    def test_filter_validator_payload_filters_content_by_identifier(self):
+        payload = {
+            "content": [
+                {"identifier": "doc-1", "name": "Alpha"},
+                {"identifier": "doc-2", "name": "Beta"},
+            ],
+            "meta": {"page": 1},
+        }
+
+        filtered = cli._filter_validator_payload(payload, {"doc-2"})
+
+        self.assertEqual(filtered["content"], [{"identifier": "doc-2", "name": "Beta"}])
+        self.assertEqual(filtered["meta"], {"page": 1})
+        self.assertEqual(len(payload["content"]), 2)
+
+    def test_collect_content_issues_includes_document_identifier_and_labels(self):
+        payload = {
+            "content": [
+                {
+                    "document_id": "1",
+                    "identifier": "dash-1",
+                    "name": "Revenue Dashboard",
+                    "type": "dashboard",
+                    "url": "https://omni.example/documents/1",
+                    "folder": {"name": "Finance", "path": "/Finance"},
+                    "labels": [{"name": "Verified"}],
+                    "queries_and_issues": [
+                        {
+                            "query_name": "Revenue by Month",
+                            "query_presentation_id": "query-1",
+                            "issues": [{"message": "Broken field"}],
+                        }
+                    ],
+                }
+            ]
+        }
+
+        issues = cli._collect_content_issues(payload)
+
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0]["document_identifier"], "dash-1")
+        self.assertEqual(issues[0]["document_labels"], ["Verified"])
+
+
+class MainFlowTests(unittest.TestCase):
+    @mock.patch.object(cli, "_write_json")
+    @mock.patch.object(cli, "_fetch_content_identifiers_for_labels")
+    @mock.patch.object(cli, "_fetch_validator_payload")
+    @mock.patch.object(cli, "_load_json")
+    def test_main_filters_results_and_resets_history_when_labels_change(
+        self,
+        load_json,
+        fetch_validator_payload,
+        fetch_content_identifiers_for_labels,
+        write_json,
+    ):
+        fetch_validator_payload.return_value = {
+            "content": [
+                {
+                    "document_id": "1",
+                    "identifier": "dash-1",
+                    "name": "Unverified Dashboard",
+                    "queries_and_issues": [
+                        {"query_name": "Q1", "issues": [{"message": "Old issue"}]}
+                    ],
+                },
+                {
+                    "document_id": "2",
+                    "identifier": "dash-2",
+                    "name": "Verified Dashboard",
+                    "queries_and_issues": [
+                        {"query_name": "Q2", "issues": [{"message": "Current issue"}]}
+                    ],
+                },
+            ]
+        }
+        fetch_content_identifiers_for_labels.return_value = {"dash-2"}
+        load_json.return_value = {
+            "labels": [],
+            "issues": [{"id": "stale", "summary": "stale", "raw": {}}],
+        }
+
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = cli.main(
+                [
+                    "--base-url",
+                    "https://omni.example",
+                    "--model-id",
+                    "model-1",
+                    "--api-key",
+                    "secret",
+                    "--labels",
+                    "Verified",
+                ]
+            )
+
+        self.assertEqual(exit_code, 1)
+        report = write_json.call_args_list[0].args[1]
+        history = write_json.call_args_list[1].args[1]
+        self.assertEqual(report["labels"], ["Verified"])
+        self.assertEqual(report["total_issues"], 1)
+        self.assertEqual(report["new_issues"], 1)
+        self.assertEqual(report["existing_issues"], 0)
+        self.assertEqual(report["resolved_issues"], 0)
+        self.assertEqual(history["labels"], ["Verified"])
+        self.assertIn("History labels changed", stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add client-side label filtering for Omni content-validator results, enrich issue output with content metadata, and add guardrails against accidentally committing secrets.

## Changes

- add `--labels`, repeatable `--label`, and `OMNI_LABELS` support
- fetch paginated content metadata from Omni and join it to validator results by `identifier`
- filter validator results locally for labeled runs before issue extraction
- enrich issue records with `document_identifier`, `document_labels`, and `document_owner`
- keep issue identities stable by ignoring enrichment-only metadata in history comparisons
- add local and CI secret-scanning guardrails with `gitleaks`
- update docs and tests

## Notes

- This is the base PR and should merge before PR #14.
- A follow-up PR is stacked on top for extra workflow-config ergonomics.

Thanks to @maddie-omni, the content validation queen for inspiration.