### PR TITLE
ci: prevent duplicate release-please PR races

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   issues: write


### PR DESCRIPTION
## Summary
- add workflow-level concurrency to `release-please` so overlapping pushes to `main` do not run the release job against multiple snapshots at once
- cancel older in-flight runs when a newer `main` push arrives
- reduce the chance of reopening the same release branch with a duplicate PR after a release merge

## Context
PR #16 was a stale duplicate of the already-merged `0.3.0` release PR (#15). The duplicate appears to have been created by an overlapping `release-please` run around the `main` merges for PR #14 and PR #15.

## Verification
- validated `.github/workflows/release-please.yml` with Ruby's YAML parser locally
