### PR TITLE
[codex] add omni model validator

### DIFF
--- a/.github/actions/model-validator/action.yml
+++ b/.github/actions/model-validator/action.yml
@@ -1,0 +1,255 @@
+name: Omni Model Validator
+description: >
+  Validate an Omni Analytics semantic model and post a PR comment with new, existing,
+  and resolved issues. Tracks history across runs to highlight only what changed.
+
+inputs:
+  api-key:
+    description: Omni API key (use a repository secret)
+    required: true
+  branch-name:
+    description: >
+      Omni branch name to validate. Defaults to the PR head branch.
+      Leave empty to validate the model's main branch.
+    required: false
+    default: ${{ github.head_ref }}
+  fail-on-new-only:
+    description: Only fail when new issues appear (ignore pre-existing issues)
+    required: false
+    default: "false"
+  errors-only:
+    description: Ignore warnings; only count and fail on errors
+    required: false
+    default: "false"
+  history-artifact-name:
+    description: Name of the GitHub Actions artifact used to persist issue history
+    required: false
+    default: model-validator-history
+  python-version:
+    description: Python version to use
+    required: false
+    default: "3.11"
+
+outputs:
+  total-issues:
+    description: Total number of issues after applying filters
+    value: ${{ steps.parse-report.outputs.total_issues }}
+  new-issues:
+    description: Number of new issues compared to history
+    value: ${{ steps.parse-report.outputs.new_issues }}
+  error-count:
+    description: Number of error-severity issues
+    value: ${{ steps.parse-report.outputs.error_count }}
+  warning-count:
+    description: Number of warning-severity issues
+    value: ${{ steps.parse-report.outputs.warning_count }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check validator config
+      shell: bash
+      run: |
+        if [ ! -f .omni-content-validator.yml ]; then
+          echo "::error::Missing .omni-content-validator.yml in the repo root."
+          echo "::error::Copy .omni-content-validator.example.yml to get started."
+          exit 1
+        fi
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install omni-model-validator
+      shell: bash
+      run: python -m pip install git+https://github.com/ernestoongaro/omnicles.git
+
+    - name: Find previous history artifact
+      id: history
+      uses: actions/github-script@v8
+      with:
+        github-token: ${{ github.token }}
+        script: |
+          const artifactName = '${{ inputs.history-artifact-name }}';
+          const defaultBranch = context.payload.repository.default_branch;
+
+          const runs = await github.rest.actions.listWorkflowRuns({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: context.workflow,
+            branch: defaultBranch,
+            status: 'success',
+            per_page: 5,
+          });
+
+          for (const run of runs.data.workflow_runs) {
+            const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: run.id,
+            });
+            const match = data.artifacts.find((a) => a.name === artifactName && !a.expired);
+            if (match) {
+              core.setOutput('run_id', run.id.toString());
+              return;
+            }
+          }
+          core.setOutput('run_id', '');
+
+    - name: Download history artifact
+      if: steps.history.outputs.run_id != ''
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.history-artifact-name }}
+        run-id: ${{ steps.history.outputs.run_id }}
+        path: .omni-content-validator
+        github-token: ${{ github.token }}
+
+    - name: Run model validator
+      id: validator
+      shell: bash
+      env:
+        OMNI_API_KEY: ${{ inputs.api-key }}
+        OMNI_BRANCH_NAME: ${{ inputs.branch-name }}
+      run: |
+        EXTRA_FLAGS=""
+        if [ "${{ inputs.fail-on-new-only }}" = "true" ]; then
+          EXTRA_FLAGS="$EXTRA_FLAGS --fail-on-new-only"
+        fi
+        if [ "${{ inputs.errors-only }}" = "true" ]; then
+          EXTRA_FLAGS="$EXTRA_FLAGS --errors-only"
+        fi
+        omni-model-validator \
+          --history-in .omni-content-validator/model-validator-history.json \
+          --history-out .omni-content-validator/model-validator-history.json \
+          --report-out .omni-content-validator/model-validator-report.json \
+          $EXTRA_FLAGS
+
+    - name: Parse report outputs
+      id: parse-report
+      if: always()
+      shell: bash
+      run: |
+        REPORT=.omni-content-validator/model-validator-report.json
+        if [ -f "$REPORT" ]; then
+          echo "total_issues=$(jq '.total_issues // 0' "$REPORT")" >> "$GITHUB_OUTPUT"
+          echo "new_issues=$(jq '.new_issues // 0' "$REPORT")" >> "$GITHUB_OUTPUT"
+          echo "error_count=$(jq '.error_count // 0' "$REPORT")" >> "$GITHUB_OUTPUT"
+          echo "warning_count=$(jq '.warning_count // 0' "$REPORT")" >> "$GITHUB_OUTPUT"
+        else
+          echo "total_issues=0" >> "$GITHUB_OUTPUT"
+          echo "new_issues=0" >> "$GITHUB_OUTPUT"
+          echo "error_count=0" >> "$GITHUB_OUTPUT"
+          echo "warning_count=0" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Upload history artifact
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ inputs.history-artifact-name }}
+        path: .omni-content-validator/model-validator-history.json
+        if-no-files-found: ignore
+
+    - name: Post PR comment
+      if: always() && github.event_name == 'pull_request'
+      uses: actions/github-script@v8
+      with:
+        github-token: ${{ github.token }}
+        script: |
+          const fs = require('fs');
+
+          let report = null;
+          let reportMissing = false;
+          try {
+            report = JSON.parse(
+              fs.readFileSync('.omni-content-validator/model-validator-report.json', 'utf8')
+            );
+          } catch {
+            reportMissing = true;
+            report = {
+              total_issues: 0, error_count: 0, warning_count: 0,
+              new_issues: 0, existing_issues: 0, resolved_issues: 0,
+              model_valid: null, errors_only: false,
+              new_issue_samples: [], existing_issue_samples: [], resolved_issue_samples: [],
+            };
+          }
+
+          const baseUrl = report.base_url?.replace(/\/$/, '') ?? null;
+          const modelUrl = baseUrl && report.model_id
+            ? `${baseUrl}/models/${report.model_id}/ide`
+            : null;
+          const branchLabel = report.branch_name || report.branch_id || null;
+
+          const summary = [
+            report.model_valid === false ? 'Model: **invalid**'
+              : report.model_valid === true ? 'Model: valid' : null,
+            `Errors: ${report.error_count}`,
+            `Warnings: ${report.warning_count}`,
+            report.errors_only ? 'Mode: errors only (warnings ignored)' : null,
+            `New issues: ${report.new_issues}`,
+            `Existing issues: ${report.existing_issues}`,
+            `Resolved issues: ${report.resolved_issues}`,
+            branchLabel ? `Branch: \`${branchLabel}\`` : null,
+            modelUrl ? `Model: ${modelUrl}` : null,
+            reportMissing ? '⚠️ Report missing — validator did not produce output.' : null,
+          ].filter(Boolean).join('\n');
+
+          const formatList = (items) => {
+            if (!items?.length) return '_None_';
+            return items.map((item) => {
+              const raw = item.raw || {};
+              const severity = raw.severity || (raw.is_warning ? 'warning' : 'error');
+              const badge = severity === 'warning' ? '⚠️' : '❌';
+              const location = raw.yaml_path
+                || [raw.view, raw.field].filter(Boolean).join('.')
+                || null;
+              const message = raw.message || item.summary || 'No details';
+              const autoFix = raw.auto_fix?.description_short ?? null;
+              const lines = [`- ${badge} \`${location || 'unknown location'}\`\n\n\`\`\`\n${message}\n\`\`\``];
+              if (autoFix) lines.push(`\n  _Auto-fix: ${autoFix}_`);
+              return lines.join('');
+            }).join('\n');
+          };
+
+          const marker = '<!-- omni-model-validator -->';
+          const body = [
+            marker,
+            '## Model Validator',
+            '',
+            summary,
+            '',
+            '**New issues**',
+            formatList(report.new_issue_samples),
+            '',
+            '**Existing issues**',
+            formatList(report.existing_issue_samples),
+            '',
+            '**Resolved issues**',
+            formatList(report.resolved_issue_samples),
+          ].join('\n');
+
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.payload.pull_request.number,
+            per_page: 100,
+          });
+
+          const existing = comments.find((c) => c.body?.includes(marker));
+          if (existing) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });
+          }

--- a/.github/workflow-examples/model-validator.yml
+++ b/.github/workflow-examples/model-validator.yml
@@ -1,0 +1,25 @@
+name: Model Validator
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  checks: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate-model:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run model validator
+        uses: ernestoongaro/omnicles/.github/actions/model-validator@main
+        with:
+          api-key: ${{ secrets.OMNI_API_KEY }}

--- a/.omni-content-validator.example.yml
+++ b/.omni-content-validator.example.yml
@@ -1,24 +1,30 @@
-# Checked-in config shape for customer repositories.
+# Checked-in config for omni-model-validator and omni-content-validator.
 # Rename this file to `.omni-content-validator.yml` in your repo root.
-# The CLI auto-loads it when present.
-# Keep secrets like the API key in GitHub Actions secrets or environment variables.
+# Both CLIs auto-load it when present.
+# Keep secrets (api_key) in GitHub Actions secrets or environment variables — never here.
 
-base_url: https://your-company.exploreomni.dev
+base_url: https://your-company.omniapp.co
 model_id: 00000000-0000-0000-0000-000000000000
 
-# Optional: resolve a branch by name in PRs, or pin a specific branch id.
+# Optional: resolve a branch by name. In GitHub Actions, GITHUB_HEAD_REF is
+# automatically set to the PR branch name — ideal for model validation on PRs.
 branch_name: ${GITHUB_HEAD_REF}
 # branch_id: 00000000-0000-0000-0000-000000000000
 
-# Optional: act on behalf of a user for org API keys.
-# user_id: 00000000-0000-0000-0000-000000000000
-
-# Optional: validate only a curated subset of content.
-labels:
-  - Verified
-  - Sales
-
-# Optional behavior flags.
-include_personal_folders: false
-fail_on_new_only: true
+# Optional behavior flags (apply to both validators unless noted).
+fail_on_new_only: false  # only fail when new issues appear vs history
 timeout: 60
+
+# Model validator only: treat warnings as informational, fail on errors only.
+# errors_only: false
+
+# Content validator only: validate content in personal folders.
+# include_personal_folders: false
+
+# Content validator only: restrict validation to content with these labels.
+# labels:
+#   - Verified
+#   - Sales
+
+# Content validator only: act on behalf of a user for org API keys.
+# user_id: 00000000-0000-0000-0000-000000000000

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 ![Omni Content Validator](assets/logo.png)
 
-CLI plus GitHub Actions support for running Omni Content Validator, keeping a history artifact, and surfacing new vs existing failures.
+CLI plus GitHub Actions support for running two Omni validators, keeping history artifacts, and surfacing new vs existing failures on every PR:
+
+- **`omni-content-validator`** — validates dashboard queries and filter configurations.
+- **`omni-model-validator`** — validates the semantic model YAML (views, topics, joins, fields). This is the most important check to run on model-editing PRs.
 
 ## Demo video
 
@@ -13,14 +16,51 @@ Watch the demo: https://screen.studio/share/OFqWgCI7
 Install locally with pipx:
 
 ```bash
+pipx install git+https://github.com/ernestoongaro/omnicles.git
+```
+
+Or in editable mode from a local clone:
+
+```bash
 pipx install -e .
 ```
 
-Run:
+### omni-model-validator
+
+Validates the Omni semantic model — views, topics, joins, and fields — against the YAML. Best run on every PR that touches model files.
+
+```bash
+omni-model-validator \
+  --base-url https://your-org.omniapp.co \
+  --model-id <MODEL_ID> \
+  --api-key <API_KEY> \
+  --branch-name <BRANCH_NAME>
+```
+
+By default the validator exits with code `1` if any issues exist (errors or warnings). Use `--errors-only` to treat warnings as informational only:
+
+```bash
+omni-model-validator \
+  --base-url https://your-org.omniapp.co \
+  --model-id <MODEL_ID> \
+  --api-key <API_KEY> \
+  --errors-only
+```
+
+Optional flags:
+
+- `--branch-name` to resolve and validate against an Omni branch by name.
+- `--branch-id` to validate against a specific Omni branch UUID.
+- `--errors-only` to ignore warnings and only fail on errors.
+- `--fail-on-new-only` to fail only when new issues appear vs history.
+
+### omni-content-validator
+
+Validates dashboard queries and filter configurations across your Omni content.
 
 ```bash
 omni-content-validator \
-  --base-url https://ernesto.playground.exploreomni.dev \
+  --base-url https://your-org.omniapp.co \
   --model-id <MODEL_ID> \
   --api-key <API_KEY> \
   --branch-name <BRANCH_NAME>
@@ -30,7 +70,7 @@ Validate only labeled content:
 
 ```bash
 omni-content-validator \
-  --base-url https://ernesto.playground.exploreomni.dev \
+  --base-url https://your-org.omniapp.co \
   --model-id <MODEL_ID> \
   --api-key <API_KEY> \
   --labels Verified
@@ -40,7 +80,7 @@ Or use repeated label flags:
 
 ```bash
 omni-content-validator \
-  --base-url https://ernesto.playground.exploreomni.dev \
+  --base-url https://your-org.omniapp.co \
   --model-id <MODEL_ID> \
   --api-key <API_KEY> \
   --label Verified \
@@ -63,6 +103,8 @@ If `.omni-content-validator.yml` exists in the current working directory, the CL
 
 Copy `.omni-content-validator.example.yml` to `.omni-content-validator.yml` and keep non-secret defaults there.
 
+Both `omni-model-validator` and `omni-content-validator` read from the same config file.
+
 Supported config keys:
 
 - `base_url`
@@ -70,10 +112,11 @@ Supported config keys:
 - `user_id`
 - `branch_id`
 - `branch_name`
-- `labels`
-- `include_personal_folders`
+- `labels` _(content validator only)_
+- `include_personal_folders` _(content validator only)_
 - `timeout`
 - `fail_on_new_only`
+- `errors_only` _(model validator only)_
 
 Secrets such as the API key are intentionally not supported in the config file. Keep those in environment variables or GitHub Actions secrets.
 
@@ -89,13 +132,14 @@ Supported environment overrides:
 - `OMNI_BASE_URL`
 - `OMNI_MODEL_ID`
 - `OMNI_API_KEY`
-- `OMNI_USER_ID`
-- `OMNI_LABELS` (optional comma-separated label filter, for example `Verified,Sales`)
-- `OMNI_INCLUDE_PERSONAL_FOLDERS`
+- `OMNI_BRANCH_ID` (optional, if you already know the Omni branch UUID)
+- `OMNI_BRANCH_NAME` (used to resolve the Omni branch UUID by name)
 - `OMNI_TIMEOUT` (optional request timeout in seconds)
 - `OMNI_FAIL_ON_NEW_ONLY` (optional `true`/`false`)
-- `OMNI_BRANCH_ID` (optional override if you already know the Omni branch UUID)
-- `OMNI_BRANCH_NAME` (used to resolve the Omni branch UUID by name)
+- `OMNI_ERRORS_ONLY` (optional `true`/`false`, model validator only)
+- `OMNI_USER_ID` (optional, content validator only)
+- `OMNI_LABELS` (optional comma-separated label filter, content validator only, e.g. `Verified,Sales`)
+- `OMNI_INCLUDE_PERSONAL_FOLDERS` (optional, content validator only)
 
 Minimal local setup with a checked-in config file:
 
@@ -143,42 +187,64 @@ For server-side blocking before a push lands, enable GitHub Secret Scanning and 
 
 ## GitHub Actions
 
-This repo includes live workflows for:
+This repo ships reusable composite actions so your workflow stays minimal:
+
+### Model validator (recommended for model PRs)
+
+```yaml
+# .github/workflows/model-validator.yml
+name: Model Validator
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  checks: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate-model:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ernestoongaro/omnicles/.github/actions/model-validator@main
+        with:
+          api-key: ${{ secrets.OMNI_API_KEY }}
+```
+
+The action automatically detects the PR branch via `github.head_ref`. Optional inputs:
+
+| Input | Default | Description |
+|---|---|---|
+| `api-key` | _(required)_ | Omni API key secret |
+| `branch-name` | `${{ github.head_ref }}` | Omni branch to validate |
+| `fail-on-new-only` | `false` | Only fail on new issues vs history |
+| `errors-only` | `false` | Ignore warnings; only fail on errors |
+| `history-artifact-name` | `model-validator-history` | Artifact name for history persistence |
+| `python-version` | `3.11` | Python version |
+
+Outputs available for downstream steps: `total-issues`, `new-issues`, `error-count`, `warning-count`.
+
+### Content validator
+
+Copy `.github/workflow-examples/content-validator.yml` to `.github/workflows/content-validator.yml` in your repo.
+
+### Recommended setup
+
+1. Copy `.omni-content-validator.example.yml` to `.omni-content-validator.yml` and fill in non-secret settings (`base_url`, `model_id`, and any flags).
+2. Add `OMNI_API_KEY` as a GitHub Actions secret.
+3. Push to `main` once (or trigger the workflow manually) to seed the history artifact.
+4. Open a PR — the action posts a comment with new, existing, and resolved issues.
+
+This repo includes live workflows for its own CI:
 
 - `.github/workflows/actionlint.yml`
 - `.github/workflows/release-please.yml`
 - `.github/workflows/secret-scan.yml`
-
-The content validator workflow is kept as an example in `.github/workflow-examples/content-validator.yml` so it does not run automatically in this repository. To enable it in your own repo, copy it to `.github/workflows/content-validator.yml`.
-
-The content validator example is designed to run on pushes to `main`, pull requests, and manual dispatches. It downloads the latest history artifact from the default branch, runs the validator, uploads a new history artifact, creates a check run, and posts a PR comment for pull requests.
-
-Recommended setup in your repo:
-
-- Check in `.omni-content-validator.yml` with non-secret settings such as `base_url`, `model_id`, labels, and behavior flags.
-- Configure `OMNI_API_KEY` as a GitHub Actions secret.
-- Optionally set `OMNI_*` repo variables or secrets only when you want workflow-specific overrides on top of the checked-in config.
-
-Supported GitHub env overrides:
-
-- `OMNI_API_KEY` (secret)
-- `OMNI_BASE_URL` (variable or secret)
-- `OMNI_MODEL_ID` (variable or secret)
-- `OMNI_USER_ID` (optional variable or secret)
-- `OMNI_LABELS` (optional variable or secret, comma-separated)
-- `OMNI_BRANCH_ID` (optional variable or secret)
-- `OMNI_BRANCH_NAME` (optional variable or secret)
-- `OMNI_TIMEOUT` (optional variable or secret)
-- `OMNI_FAIL_ON_NEW_ONLY` (optional variable or secret)
-- `OMNI_INCLUDE_PERSONAL_FOLDERS` (optional variable or secret)
-
-### Testing the workflow
-
-1. Copy `.github/workflow-examples/content-validator.yml` to `.github/workflows/content-validator.yml`.
-2. Copy `.omni-content-validator.example.yml` to `.omni-content-validator.yml` and fill in your non-secret settings.
-3. Add `OMNI_API_KEY` in GitHub repo settings, plus any optional override variables you want.
-4. Push to `main` once (or run the workflow manually on `main`) to seed the history artifact.
-5. Open a PR and confirm the check run plus PR comment show the validation results.
 
 ## Releases
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 
 [project.scripts]
 omni-content-validator = "omni_content_validator.cli:main"
+omni-model-validator = "omni_content_validator.cli:main_model"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/omni_content_validator/cli.py
+++ b/src/omni_content_validator/cli.py
@@ -20,6 +20,7 @@ CONFIG_KEYS = {
     "include_personal_folders",
     "timeout",
     "fail_on_new_only",
+    "errors_only",
 }
 
 
@@ -702,6 +703,243 @@ def _resolve_branch_id(args: argparse.Namespace) -> Optional[str]:
         cursor = payload.get("pageInfo", {}).get("nextCursor")
         if not cursor:
             return None
+
+
+def _model_issue_summary(issue: Any) -> str:
+    if isinstance(issue, str):
+        return issue
+    if not isinstance(issue, dict):
+        return str(issue)
+
+    message = issue.get("message", "")
+    if not isinstance(message, str):
+        message = str(message)
+
+    # OpenAPI format: view + field
+    view = issue.get("view")
+    field = issue.get("field")
+    location_parts = []
+    if isinstance(view, str) and view.strip():
+        location_parts.append(view.strip())
+    if isinstance(field, str) and field.strip():
+        location_parts.append(field.strip())
+    if location_parts:
+        location = ".".join(location_parts)
+        return f"{location}: {message}" if message else location
+
+    # Docs format: yaml_path
+    yaml_path = issue.get("yaml_path")
+    if isinstance(yaml_path, str) and yaml_path.strip():
+        return f"{yaml_path.strip()}: {message}" if message else yaml_path.strip()
+
+    return message or json.dumps(issue, sort_keys=True)
+
+
+def _issue_is_warning(issue: Any) -> bool:
+    if not isinstance(issue, dict):
+        return False
+    # OpenAPI format: severity = "error" | "warning"
+    severity = issue.get("severity")
+    if severity == "warning":
+        return True
+    if severity == "error":
+        return False
+    # Docs format: is_warning = bool
+    is_warning = issue.get("is_warning")
+    if isinstance(is_warning, bool):
+        return is_warning
+    return False
+
+
+def _fetch_model_validate_payload(args: argparse.Namespace) -> Any:
+    url = f"{args.base_url.rstrip('/')}/api/v1/models/{args.model_id}/validate"
+    headers = _build_headers(args.api_key)
+    params = {}
+    if args.branch_id:
+        params["branchId"] = args.branch_id
+
+    response = requests.get(url, headers=headers, params=params, timeout=args.timeout)
+    if not response.ok:
+        raise SystemExit(
+            f"Model validator failed: {response.status_code} {response.text}"
+        )
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise SystemExit(f"Model validator did not return JSON: {exc}") from exc
+
+    return payload
+
+
+def _parse_model_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run Omni model validator and track history",
+    )
+    parser.add_argument("--base-url")
+    parser.add_argument("--model-id")
+    parser.add_argument("--api-key")
+    parser.add_argument("--branch-id")
+    parser.add_argument("--branch-name")
+    parser.add_argument("--timeout", type=int)
+    parser.add_argument(
+        "--history-in",
+        default=".omni-content-validator/model-validator-history.json",
+    )
+    parser.add_argument(
+        "--history-out",
+        default=".omni-content-validator/model-validator-history.json",
+    )
+    parser.add_argument(
+        "--report-out",
+        default=".omni-content-validator/model-validator-report.json",
+    )
+    parser.add_argument("--raw-response-out", default=None)
+    parser.add_argument(
+        "--fail-on-new-only",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Only fail when there are new issues compared to history",
+    )
+    parser.add_argument(
+        "--errors-only",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Ignore warnings; only count and fail on errors",
+    )
+    args = parser.parse_args(argv)
+
+    config = _load_config()
+
+    args.base_url = _resolve_string_option(
+        args.base_url, "OMNI_BASE_URL", config, "base_url"
+    )
+    args.model_id = _resolve_string_option(
+        args.model_id, "OMNI_MODEL_ID", config, "model_id"
+    )
+    args.api_key = _normalize_string_value(args.api_key or os.getenv("OMNI_API_KEY"))
+    args.branch_id = _resolve_string_option(
+        args.branch_id, "OMNI_BRANCH_ID", config, "branch_id"
+    )
+    args.branch_name = _resolve_string_option(
+        args.branch_name, "OMNI_BRANCH_NAME", config, "branch_name"
+    )
+    args.timeout = _resolve_int_option(
+        args.timeout, "OMNI_TIMEOUT", config, "timeout", default=60
+    )
+    args.fail_on_new_only = _resolve_bool_option(
+        args.fail_on_new_only,
+        "OMNI_FAIL_ON_NEW_ONLY",
+        config,
+        "fail_on_new_only",
+        default=False,
+    )
+    args.errors_only = _resolve_bool_option(
+        args.errors_only,
+        "OMNI_ERRORS_ONLY",
+        config,
+        "errors_only",
+        default=False,
+    )
+    return args
+
+
+def main_model(argv: Optional[List[str]] = None) -> int:
+    args = _parse_model_args(argv)
+    _validate_args(args)
+
+    resolved_branch_id = _resolve_branch_id(args)
+    if resolved_branch_id:
+        args.branch_id = resolved_branch_id
+        if args.branch_name:
+            print(f"Resolved branch '{args.branch_name}' to id {resolved_branch_id}")
+        else:
+            print(f"Using branch id {resolved_branch_id}")
+    elif args.branch_name:
+        print(f"No matching Omni branch found for '{args.branch_name}', using default")
+
+    payload = _fetch_model_validate_payload(args)
+
+    if args.raw_response_out:
+        _write_json(args.raw_response_out, {"payload": payload})
+
+    if isinstance(payload, dict):
+        raw_issues = payload.get("issues", [])
+        if not isinstance(raw_issues, list):
+            raw_issues = []
+    elif isinstance(payload, list):
+        raw_issues = payload
+    else:
+        raw_issues = []
+
+    all_normalized = [
+        {"id": _issue_identity(issue), "summary": _model_issue_summary(issue), "raw": issue}
+        for issue in raw_issues
+    ]
+
+    if args.errors_only:
+        normalized = [item for item in all_normalized if not _issue_is_warning(item["raw"])]
+    else:
+        normalized = all_normalized
+
+    error_count = sum(1 for item in all_normalized if not _issue_is_warning(item["raw"]))
+    warning_count = sum(1 for item in all_normalized if _issue_is_warning(item["raw"]))
+
+    previous_payload = _load_json(args.history_in) or {}
+    previous_issues = previous_payload.get("issues", [])
+
+    new_items, existing_items, resolved_items = _partition_issues(
+        normalized, previous_issues
+    )
+
+    model_valid = payload.get("valid") if isinstance(payload, dict) else None
+
+    report = {
+        "generated_at": datetime.datetime.utcnow().isoformat() + "Z",
+        "base_url": args.base_url,
+        "model_id": args.model_id,
+        "branch_id": args.branch_id,
+        "branch_name": args.branch_name,
+        "model_valid": model_valid,
+        "errors_only": args.errors_only,
+        "total_issues": len(normalized),
+        "error_count": error_count,
+        "warning_count": warning_count,
+        "new_issues": len(new_items),
+        "existing_issues": len(existing_items),
+        "resolved_issues": len(resolved_items),
+        "issues": normalized,
+        "new_issue_samples": new_items[:20],
+        "existing_issue_samples": existing_items[:20],
+        "resolved_issue_samples": resolved_items[:20],
+    }
+
+    _write_json(args.report_out, report)
+    _write_json(
+        args.history_out,
+        {
+            "generated_at": report["generated_at"],
+            "base_url": args.base_url,
+            "model_id": args.model_id,
+            "branch_id": args.branch_id,
+            "errors_only": args.errors_only,
+            "issues": normalized,
+        },
+    )
+
+    print(
+        "Model validator results: "
+        f"errors={error_count} "
+        f"warnings={warning_count} "
+        f"total={report['total_issues']} "
+        f"new={report['new_issues']} "
+        f"existing={report['existing_issues']} "
+        f"resolved={report['resolved_issues']}"
+    )
+
+    if args.fail_on_new_only:
+        return 1 if report["new_issues"] > 0 else 0
+    return 1 if report["total_issues"] > 0 else 0
 
 
 def main(argv: Optional[List[str]] = None) -> int:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -490,5 +490,149 @@ class MainFlowTests(unittest.TestCase):
         )
 
 
+class ModelIssueTests(unittest.TestCase):
+    def test_model_issue_summary_openapi_format(self):
+        issue = {"message": "Field not found", "severity": "error", "view": "orders", "field": "total"}
+        self.assertEqual(cli._model_issue_summary(issue), "orders.total: Field not found")
+
+    def test_model_issue_summary_docs_format(self):
+        issue = {"message": "No view found", "is_warning": False, "yaml_path": "blob_sales.topic"}
+        self.assertEqual(cli._model_issue_summary(issue), "blob_sales.topic: No view found")
+
+    def test_model_issue_summary_message_only(self):
+        issue = {"message": "Something is wrong", "severity": "warning"}
+        self.assertEqual(cli._model_issue_summary(issue), "Something is wrong")
+
+    def test_issue_is_warning_openapi(self):
+        self.assertTrue(cli._issue_is_warning({"severity": "warning"}))
+        self.assertFalse(cli._issue_is_warning({"severity": "error"}))
+
+    def test_issue_is_warning_docs_format(self):
+        self.assertTrue(cli._issue_is_warning({"is_warning": True}))
+        self.assertFalse(cli._issue_is_warning({"is_warning": False}))
+
+    def test_issue_is_warning_defaults_false(self):
+        self.assertFalse(cli._issue_is_warning({"message": "no severity field"}))
+
+
+class ModelValidatorMainTests(unittest.TestCase):
+    @mock.patch.object(cli, "_write_json")
+    @mock.patch.object(cli, "_fetch_model_validate_payload")
+    @mock.patch.object(cli, "_load_json")
+    def test_main_model_reports_error_and_warning_counts(
+        self, load_json, fetch_payload, write_json
+    ):
+        fetch_payload.return_value = {
+            "valid": False,
+            "issues": [
+                {"message": "Bad view", "severity": "error", "view": "orders", "field": "total"},
+                {"message": "Deprecated field", "severity": "warning", "view": "users", "field": "name"},
+            ],
+        }
+        load_json.return_value = {"issues": []}
+
+        exit_code = cli.main_model(
+            [
+                "--base-url", "https://omni.example",
+                "--model-id", "model-1",
+                "--api-key", "secret",
+            ]
+        )
+
+        self.assertEqual(exit_code, 1)
+        report = write_json.call_args_list[0].args[1]
+        self.assertEqual(report["error_count"], 1)
+        self.assertEqual(report["warning_count"], 1)
+        self.assertEqual(report["total_issues"], 2)
+        self.assertFalse(report["model_valid"])
+
+    @mock.patch.object(cli, "_write_json")
+    @mock.patch.object(cli, "_fetch_model_validate_payload")
+    @mock.patch.object(cli, "_load_json")
+    def test_main_model_errors_only_excludes_warnings(
+        self, load_json, fetch_payload, write_json
+    ):
+        fetch_payload.return_value = {
+            "valid": False,
+            "issues": [
+                {"message": "Bad view", "severity": "error", "view": "orders"},
+                {"message": "Deprecated field", "severity": "warning", "view": "users"},
+            ],
+        }
+        load_json.return_value = {"issues": []}
+
+        exit_code = cli.main_model(
+            [
+                "--base-url", "https://omni.example",
+                "--model-id", "model-1",
+                "--api-key", "secret",
+                "--errors-only",
+            ]
+        )
+
+        self.assertEqual(exit_code, 1)
+        report = write_json.call_args_list[0].args[1]
+        self.assertEqual(report["total_issues"], 1)
+        self.assertEqual(report["error_count"], 1)
+        self.assertEqual(report["warning_count"], 1)
+        self.assertTrue(report["errors_only"])
+
+    @mock.patch.object(cli, "_write_json")
+    @mock.patch.object(cli, "_fetch_model_validate_payload")
+    @mock.patch.object(cli, "_load_json")
+    def test_main_model_valid_returns_zero(
+        self, load_json, fetch_payload, write_json
+    ):
+        fetch_payload.return_value = {"valid": True, "issues": []}
+        load_json.return_value = {"issues": []}
+
+        exit_code = cli.main_model(
+            [
+                "--base-url", "https://omni.example",
+                "--model-id", "model-1",
+                "--api-key", "secret",
+            ]
+        )
+
+        self.assertEqual(exit_code, 0)
+        report = write_json.call_args_list[0].args[1]
+        self.assertTrue(report["model_valid"])
+        self.assertEqual(report["total_issues"], 0)
+
+    @mock.patch.object(cli, "_write_json")
+    @mock.patch.object(cli, "_fetch_model_validate_payload")
+    @mock.patch.object(cli, "_load_json")
+    def test_main_model_tracks_new_and_resolved(
+        self, load_json, fetch_payload, write_json
+    ):
+        current_issue = {"message": "Bad view", "severity": "error", "view": "orders"}
+        fetch_payload.return_value = {"valid": False, "issues": [current_issue]}
+
+        # Simulate a previously recorded issue that is now gone
+        old_issue = {"message": "Old problem", "severity": "error", "view": "sales"}
+        old_normalized = [
+            {
+                "id": cli._issue_identity(old_issue),
+                "summary": cli._model_issue_summary(old_issue),
+                "raw": old_issue,
+            }
+        ]
+        load_json.return_value = {"issues": old_normalized}
+
+        exit_code = cli.main_model(
+            [
+                "--base-url", "https://omni.example",
+                "--model-id", "model-1",
+                "--api-key", "secret",
+            ]
+        )
+
+        self.assertEqual(exit_code, 1)
+        report = write_json.call_args_list[0].args[1]
+        self.assertEqual(report["new_issues"], 1)
+        self.assertEqual(report["resolved_issues"], 1)
+        self.assertEqual(report["existing_issues"], 0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add an omni-model-validator CLI entry point with history tracking
- add model validator GitHub composite action and workflow example
- document shared config and model-validator options

## Validation
- python3 -m unittest discover -s tests